### PR TITLE
csound-expression.cabal: Reduce version of temporal-media

### DIFF
--- a/packages/legacy/csound-expression/csound-expression.cabal
+++ b/packages/legacy/csound-expression/csound-expression.cabal
@@ -89,7 +89,7 @@ Library
         containers,
         csound-expression-typed >= 0.2.8,
         csound-expression-dynamic >= 0.4.0.0,
-        temporal-media >= 0.6.4,
+        temporal-media >= 0.6.3,
         csound-expression-opcodes >= 0.0.5.4,
         text
   default-language: Haskell2010


### PR DESCRIPTION
temporal-media-0.6.4 doesn't exist on Hackage, nor does it exist at the [source repository](https://github.com/spell-music/temporal-media).

I'm assuming the change from 0.6.3 to 0.6.4 was just a typo which happened while bumping cabal versions for the csound-expression 5.4.4.1 release.